### PR TITLE
Remove reference to nonexistent package

### DIFF
--- a/action_execution_ros/ae_data_visualiser/setup.py
+++ b/action_execution_ros/ae_data_visualiser/setup.py
@@ -3,9 +3,6 @@
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
-dist_setup = generate_distutils_setup(
-    packages=['ae_data_visualiser'],
-    package_dir={'ae_data_visualiser': 'ros/src/ae_data_visualiser'}
-)
+dist_setup = generate_distutils_setup()
 
 setup(**dist_setup)

--- a/action_execution_ros/ae_test_scenario_visualiser/setup.py
+++ b/action_execution_ros/ae_test_scenario_visualiser/setup.py
@@ -3,9 +3,6 @@
 from distutils.core import setup
 from catkin_pkg.python_setup import generate_distutils_setup
 
-dist_setup = generate_distutils_setup(
-    packages=['ae_test_scenario_visualiser'],
-    package_dir={'ae_test_scenario_visualiser': 'ros/src/ae_test_scenario_visualiser'}
-)
+dist_setup = generate_distutils_setup()
 
 setup(**dist_setup)


### PR DESCRIPTION
The package ae_test_scenario_visualiser fails to build because a nonexistent package is referenced in `setup.py`. This pull request removes the reference.

Travis builds of `mas_domestic_robotics` depend on this, see https://github.com/b-it-bots/mas_domestic_robotics/issues/122.